### PR TITLE
Handle eieio subclasses

### DIFF
--- a/marshal.el
+++ b/marshal.el
@@ -331,11 +331,13 @@
          (marshal-info (cdr (assoc type (marshal-get-marshal-info obj)))))
     (marshal-open driver)
     (when marshal-info
+      (when (and hint (not (eq hint (eieio-object-class obj))))
+        (marshal-write driver (marshal-get-class-slot hint)
+                       (eieio-object-class obj)))
       (dolist (s (object-slots obj))
         (let ((path (cdr (assoc s marshal-info))))
           (when (and path
                      (slot-boundp obj s))
-            
             (marshal-write driver path
                            (marshal-internal
                             (eieio-oref obj s)

--- a/marshal.el
+++ b/marshal.el
@@ -385,7 +385,12 @@
 
 (defun unmarshal-internal (obj blob type)
   (let ((obj (if (class-p obj)
-                 (make-instance obj)
+                 (let ((driver (marshal-get-driver type)))
+                   (marshal-open driver blob)
+                   (let ((cls (or (marshal-read driver (marshal-get-class-slot obj))
+                                  obj)))
+                     (marshal-close driver)
+                     (make-instance cls)))
                obj)))
     (unmarshal--internal obj blob type)))
 

--- a/marshal.el
+++ b/marshal.el
@@ -426,6 +426,8 @@
                                 'ignore))
          (base-cls (or (plist-get options :marshal-base-cls)
                        'marshal-base))
+         (cls-slot (or (plist-get options :marshal-class-slot)
+                       :-cls))
          (marshal-info (marshal--transpose-alist2
                         (remove nil
                                 (mapcar
@@ -455,6 +457,14 @@
        (defclass ,name (,@superclass ,base-cls)
          (,@slots)
          ,@options-and-doc)
+
+       (defmethod marshal-get-class-slot :static ((obj ,name))
+         (let ((cls (if (eieio-object-p obj)
+                        (eieio-object-class obj)
+                      obj)))
+           (get cls :marshal-class-slot)))
+
+       (put ',name :marshal-class-slot ',cls-slot)
 
        (defmethod marshal-get-marshal-info :static ((obj ,name))
          (let ((cls (if (eieio-object-p obj)

--- a/test/marshal-test.el
+++ b/test/marshal-test.el
@@ -138,5 +138,25 @@
                                'json)
                     'json)))))
 
+(marshal-defclass marshal-test:composite ()
+  ((obj :initarg :obj :marshal-type marshal-test:base :marshal (plist))))
+
+(marshal-defclass marshal-test:base ()
+  ((a :initarg :a :marshal (plist)))
+  :marshal-class-slot :clazz)
+
+(marshal-defclass marshal-test:derived (marshal-test:base)
+  ((b :initarg :b :marshal (plist))))
+
+(ert-deftest marshal-test:plist-subclass-roundtrip ()
+  (let* ((obj (make-instance 'marshal-test:composite
+                            :obj (make-instance 'marshal-test:derived
+                                                :a 42 :b 0)))
+         (marsh (marshal obj 'plist))
+         (unmarsh (unmarshal 'marshal-test:composite marsh 'plist)))
+    (should (eq (plist-get (plist-get marsh 'obj) :clazz)
+                'marshal-test:derived))
+    (should (equal (oref (oref unmarsh :obj) :b) 0))))
+
 (provide 'marshal-test)
 ;;; marshal-test.el ends here


### PR DESCRIPTION
This addresses #4 

We want to be able to perform round-trip conversions even when subclasses are involved. Therefore we need a way to store exact type information when needed, to disambiguate.