### PR TITLE
bugfix: wrong driver mode for null blobs

### DIFF
--- a/marshal.el
+++ b/marshal.el
@@ -386,10 +386,16 @@
 (defun unmarshal-internal (obj blob type)
   (let ((obj (if (class-p obj)
                  (let ((driver (marshal-get-driver type)))
-                   (marshal-open driver blob)
-                   (let ((cls (or (marshal-read driver (marshal-get-class-slot obj))
-                                  obj)))
-                     (marshal-close driver)
+                   (let ((cls (or (and
+                                   (not (null blob))
+                                   (let ((driver (marshal-get-driver type)))
+                                     (prog2
+                                         (marshal-open driver blob)
+                                         (marshal-read
+                                          driver
+                                          (marshal-get-class-slot obj))
+                                       (marshal-close driver))))
+                                  obj))) 
                      (make-instance cls)))
                obj)))
     (unmarshal--internal obj blob type)))

--- a/test/marshal-test.el
+++ b/test/marshal-test.el
@@ -138,5 +138,10 @@
                                'json)
                     'json)))))
 
+(ert-deftest marshal-test:null-blob ()
+  (should (eq 'marshal-test:level0
+              (eieio-object-class
+               (unmarshal 'marshal-test:level0 nil nil)))))
+
 (provide 'marshal-test)
 ;;; marshal-test.el ends here


### PR DESCRIPTION
special-case null blobs as they would open a write driver instead of a read one.
We won't get a class hint in those anyway.

This closes #7 